### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,6 @@ FROM base
 COPY --from=installer --chown=harmony /opt/harmony /opt/harmony
 WORKDIR /opt/harmony
 ENV INDEX=1
+RUN chmod +x /opt/harmony/docker-entrypoint.sh
 ENTRYPOINT ["/opt/harmony/docker-entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
although the build is working, when the `ENTRYPOINT` is run there is an permission error because it's not executable:
```
Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "/opt/harmony/docker-entrypoint.sh": permission denied: unknown
```